### PR TITLE
Fix TypeScript comment chars

### DIFF
--- a/add_license_headers.py
+++ b/add_license_headers.py
@@ -269,7 +269,7 @@ MAP_LANGUAGE_TO_COMMENT_CHARS = \
         'Scala': ['/**', ' * ', ' */'],
         'Shell': ['', '# ', ''],
         'TeX': ['', '% ', ''],
-        'TypeScript': ['/**', '* ', '*/'],
+        'TypeScript': ['/**', ' * ', '*/'],
         'VimL': [], # TODO
         'Visual Basic': [], # TODO
         'XML': ['<!--', '', ' --!>'],


### PR DESCRIPTION
It should include a `' '` similar to C/C++/etc.

# Problem

The * in the comment lines should be aligned. tslint standard rules enforces this.

# Solution

Include the space

# Result

Adds in a space