### PR TITLE
Add support for .cc files

### DIFF
--- a/add_license_headers.py
+++ b/add_license_headers.py
@@ -58,6 +58,7 @@ MAP_EXTENTION_TO_LANGUAGE = \
         '.bib': 'TeX',
         '.builder': 'Ruby',
         '.c': 'C',
+        '.cc': 'C++',
         '.c++': 'C++',
         '.clj': 'Clojure',
         '.cmake': 'CMake',


### PR DESCRIPTION
MAP_EXTENTION_TO_LANGUAGE does not contain `.cc` extension for C++.
This PR adds the support for the said extension.