### PR TITLE
Added swift support

### DIFF
--- a/add_license_headers.py
+++ b/add_license_headers.py
@@ -165,6 +165,7 @@ MAP_EXTENTION_TO_LANGUAGE = \
         '.sh': 'Shell',
         '.sql': 'SQL',
         '.sty': 'TeX',
+        '.swift': 'Objective-C',
         '.tcc': 'C++',
         '.tex': 'TeX',
         '.thor': 'Ruby',


### PR DESCRIPTION


# Problem

Some iOS open source projects can use swift so the file type should be supported.

# Solution

Added .swift extension for Objective-C to MAP_EXTENTION_TO_LANGUAGE. Objective-C and Swift share the same comment style.
